### PR TITLE
Move logging config to main() and init all loggers

### DIFF
--- a/asekuro/__init__.py
+++ b/asekuro/__init__.py
@@ -3,8 +3,3 @@ import logging
 __version__ = "0.0.6"
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
-
-logging.basicConfig(
-    level=logging.DEBUG,
-    format='%(asctime)s [%(filename)s:%(funcName)s:%(lineno)d] %(levelname)s - %(message)s'
-)


### PR DESCRIPTION
This should most of @NielsZeilemaker's comments about logging. I believe the `basicConfig` should go into `main()` and not in the module on after the `__name__` stuff (as it gets executed on import), but that's for Niels to check.

Didn't fix the `sys.exit()` though.