### PR TITLE
Minimize setup_requires in setup.py a bit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ def load_readme():
     with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
         return f.read()
 
+
 setup(
     name='asekuro',
     version=asekuro.__version__,
@@ -24,13 +25,10 @@ setup(
     url='https://github.com/godatadriven/asekuro',
     packages=find_packages(),
     python_requires='>=3.6',
-    install_requires=['pytest==3.7.0',
-                      'nbval==0.9.1',
-                      'fire==0.1.3',
-                      'nbformat==4.4.0',
-                      'ipython==6.5.0',
-                      'jupyter-client==5.2.3',
-                      'jupyter-core==4.4.0'],
+    install_requires=['pytest>=3',
+                      'nbval>=0.9',
+                      'fire>=0.1',
+                      'nbformat>=4'],
     classifiers=['Topic :: Software Development :: Build Tools',
                  'Topic :: Utilities',
                  'Framework :: Jupyter',


### PR DESCRIPTION
Remove pins to specific versions (I guessed some lower bounds) and dependencies that should be handled by `nbval` and`nbformat` (see [here](https://packaging.python.org/discussions/install-requires-vs-requirements/)).